### PR TITLE
fix(settings): open Settings on reopen via self-managed window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,8 +450,30 @@ conventional behaviour; each is intentional and load-bearing.
   (a status badge + the "Open Accessibility Settings…" button; launch-at-login and
   hide-menu-bar-icon toggles, SMAppService for login). Keep the menu bar minimal —
   Enable / Check for Updates / Settings / Quit — and do not add first-run alerts or
-  onboarding/warning items. The status item, once hidden, is restored by re-opening
-  the app (`applicationShouldHandleReopen`).
+  onboarding/warning items.
+- **Re-opening the app OPENS SETTINGS — it must NEVER reset the hide-icon flag.**
+  When the menu-bar icon is hidden, the status item is the only route to
+  Settings/Quit, so a user who re-invokes the app (Finder/Spotlight/`open` of the
+  already-running instance → `applicationShouldHandleReopen`) needs recovery. The
+  fix is to OPEN SETTINGS (the conventional "reopening a menu-bar app surfaces its
+  window"), **not** to flip `hideMenuBarIcon` back to `false` — silently un-hiding
+  the icon is the documented anti-behavior the user reported. Settings is where they
+  re-show the icon or Quit; the hide preference is respected.
+- **Settings is a self-managed `NSWindow` (`SettingsWindowController`), NOT SwiftUI's
+  `Settings` scene.** Verified on macOS 26: `NSApp.sendAction(Selector("showSettingsWindow:"),
+  to: nil, from: nil)` reports handled (returns `true`) yet NO window ever materializes
+  when invoked from `applicationShouldHandleReopen` in an accessory (`LSUIElement`) app
+  — even after `setActivationPolicy(.regular)`. So there is no `Settings {}` scene;
+  both the menu's "Settings…" item and the reopen handler route through
+  `appState.openSettings()` → `SettingsWindowController.show()`, which reuses one
+  window. Two load-bearing details: (1) the window hosts a WRAPPER view
+  (`SettingsWindowRoot`) whose `body` applies `.localized(with:)` so the locale reads
+  live inside a re-evaluated body — `NSHostingView` then switches language live; a
+  fixed root view passed to `NSHostingView.init` freezes the locale captured at
+  creation. (2) an accessory app is not auto-activated, so `orderFrontRegardless()`
+  (not `NSApp.activate()`, which is cooperative and can be denied) is what reliably
+  raises the window above the frontmost app. `windowWillClose` stops the AX poll
+  (mirrors `SettingsRootView.onDisappear`, which is unreliable for a reused window).
 
 ## Internationalization (in-app override, 9 languages)
 

--- a/Sources/CloseUp/AppDelegate.swift
+++ b/Sources/CloseUp/AppDelegate.swift
@@ -8,8 +8,16 @@ import SwiftUI
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let appState = AppState()
 
+    /// AppKit-managed Settings window (owned here, not by `AppState`, so its
+    /// SwiftUI content — which retains `AppState` — does not form a retain cycle).
+    private lazy var settingsWindowController = SettingsWindowController(appState: appState)
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         appState.start()
+        // Route the menu's "Settings…" item to the same AppKit-managed window
+        // that the reopen handler uses (SwiftUI's `Settings` scene can't be opened
+        // from `applicationShouldHandleReopen` in an accessory app).
+        appState.settingsPresenter = { [weak self] in self?.settingsWindowController.show() }
 
         #if DEBUG
         // On-screen verification hook: render the settings UI in a real window at
@@ -22,7 +30,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             NSApp.setActivationPolicy(.regular)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                self.showSettingsForScreenshot()
+                self.settingsWindowController.show()
             }
         }
         #endif
@@ -58,32 +66,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         walk(mainMenu)
     }
 
-    #if DEBUG
-    private var screenshotWindow: NSWindow?
-
-    private func showSettingsForScreenshot() {
-        let root = SettingsRootView().localized(with: appState)
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: DS.Window.settingsWidth, height: DS.Window.settingsHeight),
-            styleMask: [.titled, .closable],
-            backing: .buffered, defer: false
-        )
-        window.title = "CloseUp"
-        window.contentView = NSHostingView(rootView: root)
-        window.center()
-        window.isReleasedWhenClosed = false
-        screenshotWindow = window
-        NSApp.activate(ignoringOtherApps: true)
-        window.makeKeyAndOrderFront(nil)
-    }
-    #endif
-
-    /// Re-opening the app (Finder/Spotlight launch of the already-running
-    /// instance) un-hides the menu-bar icon. It is the only route to Settings/Quit,
-    /// so a hidden-icon user needs this recovery: reset the hide flag instead of
-    /// opening a window.
+    /// Re-opening the app (Finder/Spotlight/`open` launch of the already-running
+    /// instance) opens Settings, matching the convention that reopening a
+    /// menu-bar app surfaces its main window. This is the recovery route for a
+    /// user who hid the menu-bar icon: it must NOT reset the hide flag (the user
+    /// asked to keep the icon hidden), and Settings is where they can un-hide it
+    /// or reach Quit. `SettingsWindowController` raises the window above other
+    /// apps since an accessory (`LSUIElement`) app is not auto-activated.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        if appState.hideMenuBarIcon { appState.hideMenuBarIcon = false }
+        settingsWindowController.show()
         return true
     }
 

--- a/Sources/CloseUp/AppState.swift
+++ b/Sources/CloseUp/AppState.swift
@@ -139,6 +139,22 @@ final class AppState {
         shortcuts.isAtDefault(shortcut)
     }
 
+    // MARK: - Settings window
+
+    /// Presents the Settings window. Wired by `AppDelegate` at launch because the
+    /// window is AppKit-managed (`SettingsWindowController`): SwiftUI's `Settings`
+    /// scene cannot be opened from the reopen handler in an accessory
+    /// (`LSUIElement`) app. Held as a closure so `AppState` never retains the
+    /// window (whose SwiftUI content already retains `AppState`). Both the menu's
+    /// "Settings…" item and reopening the app route through `openSettings()`.
+    @ObservationIgnored
+    var settingsPresenter: (() -> Void)?
+
+    /// Show the Settings window (creating it on first use) and bring it forward.
+    func openSettings() {
+        settingsPresenter?()
+    }
+
     // MARK: - Init
 
     init() {

--- a/Sources/CloseUp/CloseUpApp.swift
+++ b/Sources/CloseUp/CloseUpApp.swift
@@ -30,10 +30,10 @@ struct CloseUpApp: App {
         }
         .menuBarExtraStyle(.menu)
 
-        Settings {
-            SettingsRootView()
-                .localized(with: appState)
-        }
+        // No SwiftUI `Settings` scene: its `showSettingsWindow:` responder does
+        // not open the window from the reopen handler in an accessory app (see
+        // `SettingsWindowController`), so Settings is presented from a
+        // self-managed `NSWindow` reached via `appState.openSettings()`.
     }
 }
 

--- a/Sources/CloseUp/UI/MenuBarView.swift
+++ b/Sources/CloseUp/UI/MenuBarView.swift
@@ -6,7 +6,6 @@ import SwiftUI
 /// to follow the in-app language override rather than the system language.
 struct MenuBarView: View {
     @Environment(AppState.self) private var appState
-    @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         @Bindable var appState = appState
@@ -22,8 +21,10 @@ struct MenuBarView: View {
         }
 
         Button(appState.loc("Settings…")) {
-            openSettings()
-            frontSettingsWindow()
+            // AppKit-managed window shared with the reopen handler; SwiftUI's
+            // `Settings` scene can't be opened from the reopen path in an
+            // accessory app, so CloseUp does not use it. See `SettingsWindowController`.
+            appState.openSettings()
         }
         .keyboardShortcut(",", modifiers: .command)
 
@@ -31,30 +32,5 @@ struct MenuBarView: View {
             NSApplication.shared.terminate(nil)
         }
         .keyboardShortcut("q", modifiers: .command)
-    }
-
-    /// Bring the Settings window all the way to the front of the desktop.
-    ///
-    /// CloseUp is an accessory (`LSUIElement`) app, so the system does not
-    /// activate it when one of its windows opens — and the SwiftUI Settings
-    /// window is an ordinary level-0 window, so it would otherwise open *behind*
-    /// whatever app is frontmost. `NSApp.activate()` is cooperative and can be
-    /// denied (it is, when the menu is driven without a genuine app switch), so
-    /// it cannot be relied on alone; `orderFrontRegardless()` guarantees the
-    /// window rises above other apps either way (the non-deprecated equivalent of
-    /// the old `activate(ignoringOtherApps:)`). `openSettings()` may create the
-    /// window asynchronously, so retry briefly until it exists.
-    private func frontSettingsWindow(attempt: Int = 0) {
-        NSApp.activate()
-        if let window = NSApp.windows.first(where: {
-            $0.identifier?.rawValue.contains("Settings") == true
-        }) {
-            window.makeKeyAndOrderFront(nil)
-            window.orderFrontRegardless()
-        } else if attempt < 5 {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                frontSettingsWindow(attempt: attempt + 1)
-            }
-        }
     }
 }

--- a/Sources/CloseUp/UI/SettingsWindowController.swift
+++ b/Sources/CloseUp/UI/SettingsWindowController.swift
@@ -1,0 +1,83 @@
+import AppKit
+import CloseUpKit
+import SwiftUI
+
+/// Owns the single Settings window.
+///
+/// CloseUp presents Settings from a self-managed `NSWindow` hosting
+/// `SettingsRootView` rather than SwiftUI's `Settings` scene. The scene's
+/// `showSettingsWindow:` responder does NOT open the window from a plain
+/// `NSApplicationDelegate` — the reopen path — in an accessory (`LSUIElement`)
+/// app: verified on macOS 26 that `NSApp.sendAction(Selector("showSettingsWindow:"))`
+/// reports handled (returns `true`) yet no window ever materializes, even after
+/// switching to `.regular` activation. A self-managed window opens
+/// deterministically from every entry point (menu, ⌘,, and reopening a
+/// hidden-icon app) and reuses one instance.
+@MainActor
+final class SettingsWindowController: NSObject, NSWindowDelegate {
+    private unowned let appState: AppState
+    private var window: NSWindow?
+
+    init(appState: AppState) {
+        self.appState = appState
+    }
+
+    /// Show the Settings window, creating it on first use, and raise it above
+    /// other apps — an accessory app is not auto-activated when a window opens,
+    /// so `orderFrontRegardless()` is required to surface it over the frontmost
+    /// app. Idempotent: a second call just re-fronts the existing window.
+    func show() {
+        Log.app.notice("present Settings window")
+        let window = ensureWindow()
+        // Mirror `GeneralSettingsPane.onAppear` on every open (a reused window's
+        // SwiftUI `.onAppear` does not re-fire), so the AX badge is current.
+        appState.refreshAccessibilityStatus()
+        NSApp.activate()
+        window.makeKeyAndOrderFront(nil)
+        // An accessory app is not auto-activated, so `NSApp.activate()` (cooperative)
+        // may be denied; `orderFrontRegardless()` still raises the window above the
+        // frontmost app's windows — this is what makes reopen reliably surface it.
+        window.orderFrontRegardless()
+    }
+
+    private func ensureWindow() -> NSWindow {
+        if let window { return window }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: DS.Window.settingsWidth, height: DS.Window.settingsHeight),
+            styleMask: [.titled, .closable],
+            backing: .buffered, defer: false
+        )
+        // `NSWindow.title` is a native-bridging surface that bypasses the injected
+        // locale; the brand name is locale-independent so it needs no live update.
+        window.title = "CloseUp"
+        // Host a wrapper whose `body` applies `.localized`, so the locale reads
+        // happen inside a re-evaluated body: `NSHostingView` then re-renders on a
+        // language change and the Settings UI switches live. A fixed root view
+        // would freeze the locale captured when the window was created.
+        window.contentView = NSHostingView(rootView: SettingsWindowRoot(appState: appState))
+        window.isReleasedWhenClosed = false
+        window.center()
+        window.setFrameAutosaveName("CloseUp.Settings")
+        window.delegate = self
+        self.window = window
+        return window
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        // Mirror `SettingsRootView.onDisappear`: stop polling Accessibility when
+        // the window closes. SwiftUI `.onDisappear` is unreliable for a reused
+        // AppKit window, so drive it from the window lifecycle explicitly.
+        appState.stopAccessibilityWatch()
+    }
+}
+
+/// Wrapper so the `.localized(with:)` locale reads live inside a SwiftUI `body`
+/// that `NSHostingView` re-evaluates on change — the mechanism that makes the
+/// self-managed Settings window switch language live (see `SettingsWindowController`).
+private struct SettingsWindowRoot: View {
+    let appState: AppState
+
+    var body: some View {
+        SettingsRootView().localized(with: appState)
+    }
+}

--- a/Sources/CloseUpKit/Diagnostics/Log.swift
+++ b/Sources/CloseUpKit/Diagnostics/Log.swift
@@ -25,4 +25,7 @@ public enum Log {
 
     /// Event-tap create/teardown and the system-disable re-enable path.
     public static let eventTap = Logger(subsystem: subsystem, category: "eventtap")
+
+    /// App-shell lifecycle: reopen handling, Settings-window presentation.
+    public static let app = Logger(subsystem: subsystem, category: "app")
 }


### PR DESCRIPTION
Reopening a hidden-icon app (Finder/Spotlight/`open` of the running instance) previously reset `hideMenuBarIcon` to false, silently un-hiding the menu-bar icon the user had asked to keep hidden. The intended recovery is to surface Settings instead — but SwiftUI's `Settings` scene cannot be opened from `applicationShouldHandleReopen` in an accessory (`LSUIElement`) app: verified on macOS 26 that `showSettingsWindow:` reports handled (returns `true`) yet no window ever materializes, even after switching to `.regular` activation. That's why the old code fell back to flipping the hide flag.

This presents Settings from a self-managed `NSWindow` (`SettingsWindowController`) reached through `appState.openSettings()`, shared by the menu's "Settings…" item, ⌘,, and the reopen handler. Reopen now opens that window and no longer touches the hide flag, so the hide preference is respected and Settings is where the user re-shows the icon or reaches Quit.

- `orderFrontRegardless()` raises the window above the frontmost app, since an accessory app is not auto-activated when one of its windows opens.
- The window hosts a wrapper view (`SettingsWindowRoot`) whose `body` applies `.localized`, so `NSHostingView` re-renders and the Settings UI switches language live; a fixed root view would freeze the locale captured at window creation.
- `windowWillClose` stops the Accessibility poll, mirroring `SettingsRootView.onDisappear`, which is unreliable for a reused AppKit window.